### PR TITLE
Codementor/login username fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,8 @@ export default function App() {
           <ChangeTheme theme={theme} setTheme={setTheme} />
           <UserBar
             username={username} setUsername={setUsername}
-            loggedIn={loggedIn} setLoggedIn={setLoggedIn} />
+            loggedIn={loggedIn}
+          />
           <br />
           <hr />
           <Switch>

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,6 @@ import flashMessage from './FlashMessage';
 export default function App() {
   const defaultPosts = [];
   const [username, setUsername] = useState('');
-  const [usernameRegister, setUsernameRegister] = useState('');
   const [loggedIn, setLoggedIn] = useState(false);
   const [posts, setPosts] = useState(defaultPosts);
   const [theme, setTheme] = useState({
@@ -44,7 +43,6 @@ export default function App() {
           <ChangeTheme theme={theme} setTheme={setTheme} />
           <UserBar
             username={username} setUsername={setUsername}
-            usernameRegister={usernameRegister} setUsernameRegister={setUsernameRegister}
             loggedIn={loggedIn} setLoggedIn={setLoggedIn} />
           <br />
           <hr />

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,10 @@ export default function App() {
   function findPost(posts, params) {
     return posts.find(post => post.slug === params.postSlug) || posts[0];
   }
+  function handleLogin(user) {
+    setUsername(user);
+    setLoggedIn(true);
+  }
   return (
     <ThemeContext.Provider value={theme} >
       <Router>
@@ -44,6 +48,7 @@ export default function App() {
           <UserBar
             username={username} setUsername={setUsername}
             loggedIn={loggedIn}
+            onLogin={handleLogin}
           />
           <br />
           <hr />

--- a/src/user/Login.tsx
+++ b/src/user/Login.tsx
@@ -3,11 +3,10 @@ import React, { useState, FormEvent, ChangeEvent } from 'react';
 interface loginProps {
   username: string,
   setUsername(username: string): string,
-  setLoggedIn(loggedIn: boolean): boolean
 }
 
 export default function Login(props: loginProps) {
-  const { username, setUsername, setLoggedIn } = props;
+  const { username, setUsername } = props;
   const [ password, setPassword ] = useState('');
   const [err, setErr] = useState('');
   function handleUsername(e: FormEvent<HTMLFormElement> ) {
@@ -15,7 +14,7 @@ export default function Login(props: loginProps) {
       if (password === null) { setErr('blank password'); } else {
         if (username.length < 2) { setErr('username must be at least 2 characters'); } else {
           setUsername(username);
-          setLoggedIn(true);
+          // Here is now missing a way to tell the higher level components, that we have to log in!
         }
       }
     }

--- a/src/user/Login.tsx
+++ b/src/user/Login.tsx
@@ -3,10 +3,11 @@ import React, { useState, FormEvent, ChangeEvent } from 'react';
 interface loginProps {
   username: string,
   setUsername(username: string): string,
+  onLogin(user: string): void
 }
 
 export default function Login(props: loginProps) {
-  const { username, setUsername } = props;
+  const { username, setUsername, onLogin } = props;
   const [ password, setPassword ] = useState('');
   const [err, setErr] = useState('');
   function handleUsername(e: FormEvent<HTMLFormElement> ) {
@@ -14,7 +15,7 @@ export default function Login(props: loginProps) {
       if (password === null) { setErr('blank password'); } else {
         if (username.length < 2) { setErr('username must be at least 2 characters'); } else {
           setUsername(username);
-          // Here is now missing a way to tell the higher level components, that we have to log in!
+          onLogin(username);
         }
       }
     }

--- a/src/user/Logout.tsx
+++ b/src/user/Logout.tsx
@@ -3,13 +3,12 @@ import React from 'react';
 interface LogoutProps {
   username: string,
   setUsername(username: string): string,
-  setLoggedIn(loggedIn: boolean): boolean
 }
 
-export default function Logout ({ username, setUsername, setLoggedIn }: LogoutProps) {
+export default function Logout ({ username, setUsername }: LogoutProps) {
   const logout = (e: React.FormEvent<HTMLFormElement>) => {
     setUsername('');
-    setLoggedIn(false);
+    // Here is now missing a way to tell the higher level components, that we have to log out!
     e.preventDefault();
   };
   return (

--- a/src/user/Logout.tsx
+++ b/src/user/Logout.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 interface LogoutProps {
   username: string,
   setUsername(username: string): string,
+  onLogout(): void,
 }
 
-export default function Logout ({ username, setUsername }: LogoutProps) {
+export default function Logout ({ username, setUsername, onLogout }: LogoutProps) {
   const logout = (e: React.FormEvent<HTMLFormElement>) => {
     setUsername('');
-    // Here is now missing a way to tell the higher level components, that we have to log out!
+    onLogout();
     e.preventDefault();
   };
   return (

--- a/src/user/Register.tsx
+++ b/src/user/Register.tsx
@@ -3,14 +3,13 @@ import React, { useState, FormEvent, ChangeEvent } from 'react';
 interface registerProps {
   // setUsername: string,
   usernameRegister: string,
-  setLoggedIn(loggedIn: boolean): boolean
   setUsernameRegister(usernameRegister: string): void,
 }
 
 
 export default function Register(props: registerProps) {
   // const { setUsername, usernameRegister,  setUsernameRegister, setLoggedIn } = props;
-  const { usernameRegister,  setUsernameRegister, setLoggedIn } = props;
+  const { usernameRegister,  setUsernameRegister } = props;
   const [err, setErr] = useState('');
   const [pwdRegister, setPwd] = useState('');
   const [pwdRepeat, setPwdRepeat] = useState('');
@@ -19,8 +18,7 @@ export default function Register(props: registerProps) {
       if (pwdRegister === '') { setErr('password is blank'); } else {
         if (pwdRepeat === '') { setErr('password confirm is blank'); } else {
           if (pwdRegister !== pwdRepeat) { setErr('The passwords do not match'); } else {
-            // setUsername(usernameRegister)
-            setLoggedIn(true);
+            // Here is now missing a way to tell the higher level components, that we have to log in!
           }
         };
       };

--- a/src/user/Register.tsx
+++ b/src/user/Register.tsx
@@ -3,8 +3,8 @@ import React, { useState, FormEvent, ChangeEvent } from 'react';
 interface registerProps {
   // setUsername: string,
   usernameRegister: string,
-  setUsernameRegister(usernameRegister: string): string,
   setLoggedIn(loggedIn: boolean): boolean
+  setUsernameRegister(usernameRegister: string): void,
 }
 
 

--- a/src/user/Register.tsx
+++ b/src/user/Register.tsx
@@ -4,12 +4,13 @@ interface registerProps {
   // setUsername: string,
   usernameRegister: string,
   setUsernameRegister(usernameRegister: string): void,
+  onLogin(user: string): void
 }
 
 
 export default function Register(props: registerProps) {
   // const { setUsername, usernameRegister,  setUsernameRegister, setLoggedIn } = props;
-  const { usernameRegister,  setUsernameRegister } = props;
+  const { usernameRegister,  setUsernameRegister, onLogin } = props;
   const [err, setErr] = useState('');
   const [pwdRegister, setPwd] = useState('');
   const [pwdRepeat, setPwdRepeat] = useState('');
@@ -18,7 +19,7 @@ export default function Register(props: registerProps) {
       if (pwdRegister === '') { setErr('password is blank'); } else {
         if (pwdRepeat === '') { setErr('password confirm is blank'); } else {
           if (pwdRegister !== pwdRepeat) { setErr('The passwords do not match'); } else {
-            // Here is now missing a way to tell the higher level components, that we have to log in!
+            onLogin(usernameRegister);
           }
         };
       };

--- a/src/user/UserBar.tsx
+++ b/src/user/UserBar.tsx
@@ -8,14 +8,13 @@ interface userProps {
   username: string,
   setUsername(username: string): string,
   loggedIn: boolean,
-  setLoggedIn(loggedIn: boolean): boolean
 }
 
 export default function UserBar(props: userProps) {
-  const { username, setUsername, loggedIn, setLoggedIn } = props;
+  const { username, setUsername, loggedIn } = props;
   const [ usernameRegister, setUsernameRegister ] = useState('');
   const details = () => {
-    return <Logout username={username} setUsername={setUsername} setLoggedIn={setLoggedIn} />;
+    return <Logout username={username} setUsername={setUsername} />;
   };
   if (loggedIn) { return details(); }
   return (
@@ -23,12 +22,12 @@ export default function UserBar(props: userProps) {
       <Login
         username={username}
         setUsername={setUsername}
-        setLoggedIn={setLoggedIn} />
+      />
       <Register
         // setUsername={setUsername}
         usernameRegister={usernameRegister}
         setUsernameRegister={setUsernameRegister}
-        setLoggedIn={setLoggedIn} />
+      />
     </>
   );
 }

--- a/src/user/UserBar.tsx
+++ b/src/user/UserBar.tsx
@@ -7,14 +7,17 @@ import Register from './Register';
 interface userProps {
   username: string,
   setUsername(username: string): string,
-  loggedIn: boolean,
+  loggedIn: boolean
+  onLogin(user: string): void
+  onLogout(): void
 }
 
 export default function UserBar(props: userProps) {
   const { username, setUsername, loggedIn } = props;
+  const { onLogin, onLogout } = props;
   const [ usernameRegister, setUsernameRegister ] = useState('');
   const details = () => {
-    return <Logout username={username} setUsername={setUsername} />;
+    return <Logout username={username} setUsername={setUsername} onLogout={onLogout} />;
   };
   if (loggedIn) { return details(); }
   return (
@@ -22,11 +25,13 @@ export default function UserBar(props: userProps) {
       <Login
         username={username}
         setUsername={setUsername}
+        onLogin={onLogin}
       />
       <Register
         // setUsername={setUsername}
         usernameRegister={usernameRegister}
         setUsernameRegister={setUsernameRegister}
+        onLogin={onLogin}
       />
     </>
   );

--- a/src/user/UserBar.tsx
+++ b/src/user/UserBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState} from 'react';
 
 import Login from './Login';
 import Logout from './Logout';
@@ -7,14 +7,13 @@ import Register from './Register';
 interface userProps {
   username: string,
   setUsername(username: string): string,
-  usernameRegister: string,
-  setUsernameRegister(usernameRegister: string): string,
   loggedIn: boolean,
   setLoggedIn(loggedIn: boolean): boolean
 }
 
 export default function UserBar(props: userProps) {
-  const { username, setUsername, usernameRegister, setUsernameRegister, loggedIn, setLoggedIn } = props;
+  const { username, setUsername, loggedIn, setLoggedIn } = props;
+  const [ usernameRegister, setUsernameRegister ] = useState('');
   const details = () => {
     return <Logout username={username} setUsername={setUsername} setLoggedIn={setLoggedIn} />;
   };


### PR DESCRIPTION
Looks like a lot changed, but bear with me!
===

The main problem was, that there are essentially _two_ usernames in this `<App>`: `registerUsername` and `username`. However, when the user logs in, the `<App>` must know which of the two it should take.

To fix this, there are two options:

1. Introduce another bool hook like `loggedInFromRegister` and do an if else in all components to divide which of the two to render. This would be the the fastest but also least maintainable solution IMO. You can imagine that this does not scale well and when your `<App>` is growing you have to do a loooot of `if`/`else`s...

2. Let the `<UserBar>` component figure out, which the correct username is and tell that to `<App>`. This way, `<App>` will then only have one username left. This sounds much more scalable not?

This PR goes the second way in the following steps (which are the commits, if you check out each commit individually, it will be easier to understand the intention):

Step 1: Move `usernameRegister` hook into `<UserBar>` component (9e7a6ec40f3).
---

When `<App>` only has one username left, it doesn't need the `usernameRegister` hook anymore. Who does need it, though, is the `<UserBar>` component, since it has to decide, if the username from the `<Register>` or from the `<Login>` component was used.

Step 2. Remove the `setLoggedIn` setter from lower level components (40472931b42da5)
---

This refactoring follows the design from the ["Lifiting State Up"](https://reactjs.org/docs/lifting-state-up.html) philosophy:

The information, if the user should be logged in or not is held by the top level `<App>` component. It is set, though, by some lower component (namely `<Login>`, `<Register>` and `<Logout>`). These lower level components do not should not modify the state of `<App>` directly with passed down `setLoggedIn()` hooks.

Rather, the `<App>` component should be _notified_ via a callback function, whenever the user has logged in or out.

The first step is to remove the passing of the `setLoggedIn` hook down the component (this commit). The `onLogin()` and `onLogout()` callbacks will come in the next commit. For now there are only comment placeholders.


Step 3. Add `onLogin(user)` and `onLogout()` callbacks (cb246f7ad9cf)
---

Now we add new callbacks to the `<Login>`, `<Register>`, `<Logout>` and `<UserBar>` components. The `<App>` component will hand these callbacks down the component chain. When the user is logged in, `<App>` will first set the user name and then
the flag that the user is correctly logged in.

Note that `<UserBar>` passes the `onLogin` callback to _both_ the `<Login>` _and_ `<Register>` component! The `onLogin` takes one string parameter, namely the username which got logged in. The `<Login>` component will pass the input from the
login field to this callback, while the `<Register>` component will pass the text from the `registerUsername` to this callback. This way, `<App>` will be notified of the current user, regardless where the username is coming from.

Quite nice not?


Final Considerations
---

I noticed you are using React Hooks, which are very modern and clean way to structure React applications. However there is one thing to remember with the `setXXX` part of the Hooks. You don't have to pass them all the way down! Like the `setLoggedIn` is defined in `<App>` but used ultimately in low level components such as `<Login>` or `<Logout>`.

Now you might say ["But what about [Lifiting State Up](https://reactjs.org/docs/lifting-state-up.html)" and you are totally right. Whenever possible you should extract the state in higher level components. However, what I like to do, is to think about to _encapsulate_ intermediate data in components. For example:

Notice that the `<UserBar>` component holds kind of "temporary" data like the partially entered text into the inputs. These partial strings are not interessting for `<App>`. All `<App>` cares about are the validated user credentials. So what we did above was to let actually `<UserBar>` hold the `registerUsername` as temporary value and only _notify_ `<App>` via the callback `onLogin` when `<App>` should update its internal state.

This has the added benefit, that the `<App>` component is kept relatively simple. Imagine you add 100 more input fields for different parts of you application, which are all kept track of in `<App>` =S Instead if you do it with the "callback" approach you end up with `<App>` having 100 callback handling methods such as:

* `onLogin()`
* `onLogout()`
* `onRegisterUser()`
* `onDeleteUser()` and so on...

This seems a lot more maintainable to me =)

React Developer Tools
---

I don't know if you know them, but to debug such state problems for you in the future, there is a very nice tool called [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en). It is a Chrome (or Firefox, not sure though?) extension with which you can inspect _live_ the state and props of all your components. Hope this helps you in the future.
